### PR TITLE
Use walltime for tracking progress updates

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update
-        sudo apt -q install mingw-w64 zip pandoc
+        sudo apt -q install gcc-mingw-w64-x86-64-posix zip pandoc
     - name: make
       run: |
         make -j CC=x86_64-w64-mingw32-gcc \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-["You should have used WADPTR"](https://www.youtube.com/watch?v=EO849hbGP-c) - unhappily dshrunk fraggle
+wadptr is a tool for compressing Doom .wad files. It takes advantage of the
+structure of the WAD format and some of the lumps stored inside it to merge
+repeated data.
+
+Building wadptr requires a toolchain with at least C99 and POSIX.1-2008
+support, plus GNU make. Contemporary systems based on Linux, BSD,
+Solaris/Illumos, Cygwin or mingw-w64 will do.
+
+Apocrypha: ["You should have used WADPTR"](https://www.youtube.com/watch?v=EO849hbGP-c) - unhappily dshrunk fraggle

--- a/blockmap.c
+++ b/blockmap.c
@@ -180,10 +180,7 @@ static blockmap_t RebuildBlockmap(const blockmap_t *blockmap, bool compress)
         const block_t *block = &blocklist[bi];
         int match_index = -1;
 
-        if ((i % 100) == 0)
-        {
-            PrintProgress(i, blockmap->num_blocks);
-        }
+        PrintProgress(i, blockmap->num_blocks);
 #ifdef DEBUG
         printf("block %5d: len=%d\n", bi, block->len);
 #endif

--- a/main.c
+++ b/main.c
@@ -157,12 +157,18 @@ failed:
 
 void PrintProgress(int numerator, int denominator)
 {
-    static clock_t last_progress_time = 0;
+    static uint64_t last_progress_time;
     static int last_numerator = 0;
-    clock_t now = clock();
+    /*
+     * Tracking time-since-last-update needs a clock that is independent of CPU
+     * cycles spent, so clock(3) is out the question.
+     */
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t now = (uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
 
     if (numerator < last_numerator ||
-        now - last_progress_time >= (CLOCKS_PER_SEC / 20))
+        now - last_progress_time > 50000000)
     {
         SPAMMY_PRINTF("%4d%%\b\b\b\b\b", (int) (100 * numerator) / denominator);
         fflush(stdout);

--- a/sidedefs.c
+++ b/sidedefs.c
@@ -436,10 +436,7 @@ static sidedef_array_t DoPack(const sidedef_array_t *sidedefs)
     // one.
     for (mi = 0; mi < sidedefs->len; mi++)
     {
-        if ((mi % 100) == 0)
-        {
-            PrintProgress(mi, sidedefs->len);
-        }
+        PrintProgress(mi, sidedefs->len);
         sdi = map[mi];
         sidedef = &sidedefs->sides[sdi];
 #ifdef DEBUG

--- a/wadmerge.c
+++ b/wadmerge.c
@@ -92,11 +92,7 @@ void RebuildMergedWad(wad_file_t *wf, FILE *newwad)
         const lump_data_t *ld;
         int lumpnum = sorted_map[i];
 
-        if ((i % 100) == 0)
-        {
-            PrintProgress(i, wf->num_entries);
-        }
-
+        PrintProgress(i, wf->num_entries);
         cached = CacheLump(wf, lumpnum);
         HashData(cached, wf->entries[lumpnum].length, hash);
         ld = FindExistingLump(lumps, num_lumps, hash);


### PR DESCRIPTION
Avoid double rate-limiting of progress bar

PrintProgress takes care of rate-limiting screen updates, so the callers no longer need to use %n==0 tests.

---
The progress bar updates in intervals longer than 50ms, which is noticable when the program is put to sleep for one reason or another (just OS scheduling, or artifically calling nanosleep()).

For status updates, one wants to use CLOCK_MONOTONIC/CLOCK_REALTIME, i.e. a clock that increments by 1s for every human-experienced 1s. clock() uses CLOCK_PROCESS_CPUTIME_ID where there is no such guarantee.

Since portability to MS-DOS/Win32 may still be a concern, I settled for time(). This reduces the interval from 50ms to 1000ms, but oh well.